### PR TITLE
Begin adding an admin page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>19.0</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/src/main/java/codeu/controller/AdminServlet.java
+++ b/src/main/java/codeu/controller/AdminServlet.java
@@ -1,0 +1,115 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeu.controller;
+
+import codeu.model.data.Conversation;
+import codeu.model.data.User;
+import codeu.model.store.basic.ConversationStore;
+import codeu.model.store.basic.UserStore;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Servlet class responsible for the Admin page. */
+public class AdminServlet extends HttpServlet {
+
+  /** Store class that gives access to Users. */
+  private UserStore userStore;
+
+  /** Store class that gives access to Conversations. */
+  private ConversationStore conversationStore;
+
+  private static final String LOGIN_URL = "/login";
+  private static final String CONVERSATION_URL = "/conversations";
+  private static final String SELF_JSP = "/WEB-INF/view/admin.jsp";
+
+  /** Special magic username that allows access. */
+  private static final String ADMIN_USER = "admin";
+
+  /**
+   * Set up state for handling admin-related requests. This basically means
+   * we need everything. Not called in unit tests, which is a bit troubling.
+   */
+  @Override
+  public void init() throws ServletException {
+    super.init();
+    setUserStore(UserStore.getInstance());
+    setConversationStore(ConversationStore.getInstance());
+  }
+
+  /**
+   * Sets the UserStore used by this servlet. This function provides a common setup method for use
+   * by the test framework or the servlet's init() function.
+   */
+  void setUserStore(UserStore userStore) {
+    this.userStore = userStore;
+  }
+
+  /**
+   * Sets the ConversationStore used by this servlet. This function provides a common setup method
+   * for use by the test framework or the servlet's init() function.
+   */
+  void setConversationStore(ConversationStore conversationStore) {
+    this.conversationStore = conversationStore;
+  }
+
+  private boolean userIsValid(HttpServletRequest request, HttpServletResponse response)
+      throws IOException, ServletException {
+    String username = (String) request.getSession().getAttribute("user");
+    if (username == null) {
+      // user is not logged in, don't let them create a conversation
+      response.sendRedirect(LOGIN_URL);
+      return false;
+    } else if (!ADMIN_USER.equals(username)) {
+      response.sendRedirect(CONVERSATION_URL);
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  /**
+   * This function fires when a user navigates to the admin page. It gets all of the
+   * conversations from the model and forwards to admin.jsp for rendering the list.
+   * Note that this needs to gate on user.
+   */
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response)
+      throws IOException, ServletException {
+    if (userIsValid(request, response)) {
+      List<Conversation> conversations = conversationStore.getAllConversations();
+      List<User> users = userStore.getAllUsers();
+      request.setAttribute("conversations", conversations);
+      request.setAttribute("users", users);
+      request.getRequestDispatcher(SELF_JSP).forward(request, response);
+    }
+  }
+
+  /**
+   * This function fires when a user submits the form on the conversations page. It gets the
+   * logged-in username from the session and the new conversation title from the submitted form
+   * data. It uses this to create a new Conversation object that it adds to the model.
+   */
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response)
+      throws IOException, ServletException {
+      // do nothing
+  }
+}

--- a/src/main/java/codeu/controller/AdminServlet.java
+++ b/src/main/java/codeu/controller/AdminServlet.java
@@ -74,7 +74,7 @@ public class AdminServlet extends HttpServlet {
       throws IOException, ServletException {
     String username = (String) request.getSession().getAttribute("user");
     if (username == null) {
-      // user is not logged in, don't let them create a conversation
+      // user is not logged in, so force them into that first.
       response.sendRedirect(LOGIN_URL);
       return false;
     } else if (!ADMIN_USER.equals(username)) {

--- a/src/main/java/codeu/controller/BaseAdminServlet.java
+++ b/src/main/java/codeu/controller/BaseAdminServlet.java
@@ -106,13 +106,6 @@ public abstract class BaseAdminServlet extends HttpServlet {
       throws IOException, ServletException {
     if (userIsValid(request, response)) {
       onValidatedGet(request, response);
-	    /*
-      List<Conversation> conversations = conversationStore.getAllConversations();
-      List<User> users = userStore.getAllUsers();
-      request.setAttribute("conversations", conversations);
-      request.setAttribute("users", users);
-      request.getRequestDispatcher(SELF_JSP).forward(request, response);
-      */
     }
   }
 

--- a/src/main/java/codeu/controller/BaseAdminServlet.java
+++ b/src/main/java/codeu/controller/BaseAdminServlet.java
@@ -27,18 +27,17 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** Servlet class responsible for the Admin page. */
-public class AdminServlet extends HttpServlet {
+/** Absract class responsible for common functionality in all Admin pages. */
+public abstract class BaseAdminServlet extends HttpServlet {
 
   /** Store class that gives access to Users. */
-  private UserStore userStore;
+  protected UserStore userStore;
 
   /** Store class that gives access to Conversations. */
-  private ConversationStore conversationStore;
+  protected ConversationStore conversationStore;
 
   private static final String LOGIN_URL = "/login";
   private static final String CONVERSATION_URL = "/conversations";
-  private static final String SELF_JSP = "/WEB-INF/view/admin.jsp";
 
   /** Special magic username that allows access. */
   private static final String ADMIN_USER = "admin";
@@ -70,7 +69,7 @@ public class AdminServlet extends HttpServlet {
     this.conversationStore = conversationStore;
   }
 
-  private boolean userIsValid(HttpServletRequest request, HttpServletResponse response)
+  protected boolean userIsValid(HttpServletRequest request, HttpServletResponse response)
       throws IOException, ServletException {
     String username = (String) request.getSession().getAttribute("user");
     if (username == null) {
@@ -86,6 +85,18 @@ public class AdminServlet extends HttpServlet {
   }
 
   /**
+   * Functionality that an implementation class provides to fulfill a GET command.
+   */
+  protected abstract void onValidatedGet(HttpServletRequest request, HttpServletResponse response)
+      throws IOException, ServletException;
+
+  /**
+   * Functionality that an implementation class provides to fulfill a POST command.
+   */
+  protected abstract void onValidatedPost(HttpServletRequest request, HttpServletResponse response)
+      throws IOException, ServletException;
+
+  /**
    * This function fires when a user navigates to the admin page. It gets all of the
    * conversations from the model and forwards to admin.jsp for rendering the list.
    * Note that this needs to gate on user.
@@ -94,11 +105,14 @@ public class AdminServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response)
       throws IOException, ServletException {
     if (userIsValid(request, response)) {
+      onValidatedGet(request, response);
+	    /*
       List<Conversation> conversations = conversationStore.getAllConversations();
       List<User> users = userStore.getAllUsers();
       request.setAttribute("conversations", conversations);
       request.setAttribute("users", users);
       request.getRequestDispatcher(SELF_JSP).forward(request, response);
+      */
     }
   }
 
@@ -110,6 +124,8 @@ public class AdminServlet extends HttpServlet {
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response)
       throws IOException, ServletException {
-      // do nothing
+    if (userIsValid(request, response)) {
+      onValidatedPost(request, response);
+    }
   }
 }

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -122,7 +122,7 @@ public class ChatServlet extends HttpServlet {
     }
 
     User user = userStore.getUser(username);
-    if (user == null) {
+    if (user == null || user.isBlocked()) {
       // user was not found, don't let them add a message
       response.sendRedirect("/login");
       return;
@@ -132,8 +132,8 @@ public class ChatServlet extends HttpServlet {
     String conversationTitle = requestUrl.substring("/chat/".length());
 
     Conversation conversation = conversationStore.getConversationWithTitle(conversationTitle);
-    if (conversation == null) {
-      // couldn't find conversation, redirect to conversation list
+    if (conversation == null || conversation.isMuted()) {
+      // couldn't find conversation, or the conversation can't be shown: redirect to conversation list
       response.sendRedirect("/conversations");
       return;
     }

--- a/src/main/java/codeu/controller/ConversationAdminServlet.java
+++ b/src/main/java/codeu/controller/ConversationAdminServlet.java
@@ -1,0 +1,52 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeu.controller;
+
+import codeu.model.data.Conversation;
+import codeu.model.data.User;
+import codeu.model.store.basic.ConversationStore;
+import codeu.model.store.basic.UserStore;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Servlet class responsible for the Admin actions for a single conversation. */
+public class ConversationAdminServlet extends BaseAdminServlet {
+  private static final String SELF_JSP = "/WEB-INF/view/admin-conversation.jsp";
+
+  @Override
+  protected void onValidatedGet(HttpServletRequest request, HttpServletResponse response)
+      throws IOException, ServletException {
+    String conversation = request.getParameter("conversation"); 
+    Conversation conversationToBeShown = conversationStore.getConversationWithTitle(conversation);
+    if (conversationToBeShown != null) {
+      User author = userStore.getUser(conversationToBeShown.getOwnerId());
+      request.setAttribute("author", author);
+      request.setAttribute("conversationToBeShown", conversationToBeShown);
+    }
+    request.getRequestDispatcher(SELF_JSP).forward(request, response);
+  }
+
+  @Override
+  protected void onValidatedPost(HttpServletRequest request, HttpServletResponse response)
+      throws IOException, ServletException {
+    // Do nothing for now.
+  }
+}

--- a/src/main/java/codeu/controller/ConversationAdminServlet.java
+++ b/src/main/java/codeu/controller/ConversationAdminServlet.java
@@ -47,6 +47,21 @@ public class ConversationAdminServlet extends BaseAdminServlet {
   @Override
   protected void onValidatedPost(HttpServletRequest request, HttpServletResponse response)
       throws IOException, ServletException {
-    // Do nothing for now.
+    String conversation = request.getParameter("conversation"); 
+    Conversation originalConversation = conversationStore.getConversationWithTitle(conversation);
+    Conversation editedConversation;
+    String action = request.getParameter("action");    
+    if ("Mute".equals(action)) {
+      editedConversation = Conversation.muteConversation(originalConversation);
+      conversationStore.addConversation(editedConversation);
+    } else if ("Unmute".equals(action)) {
+      editedConversation = Conversation.unmuteConversation(originalConversation);
+      conversationStore.addConversation(editedConversation);
+    } else {
+      editedConversation = originalConversation;
+    }
+    request.setAttribute("author", userStore.getUser(editedConversation.getOwnerId()));
+    request.setAttribute("conversationToBeShown", editedConversation);
+    request.getRequestDispatcher(SELF_JSP).forward(request, response);
   }
 }

--- a/src/main/java/codeu/controller/LoginServlet.java
+++ b/src/main/java/codeu/controller/LoginServlet.java
@@ -92,7 +92,7 @@ public class LoginServlet extends HttpServlet {
 	} else {
           // At last, success!
           request.getSession().setAttribute("user", username);
-          response.sendRedirect("/conversations");
+          response.sendRedirect("admin".equals(username) ? "/admin" : "/conversations");
 	}
       } else {
 	setErrorAndRedirect(request, response, "Invalid password.");

--- a/src/main/java/codeu/controller/LoginServlet.java
+++ b/src/main/java/codeu/controller/LoginServlet.java
@@ -87,8 +87,13 @@ public class LoginServlet extends HttpServlet {
       // User has entered the correct password.
       // TODO(someone): add encryption to this, because this is terrible.
       if(password.equals(user.getPassword())) {
-        request.getSession().setAttribute("user", username);
-        response.sendRedirect("/conversations");
+        if (user.isBlocked()) {
+	  setErrorAndRedirect(request, response, "You have been blocked. Bummer.");
+	} else {
+          // At last, success!
+          request.getSession().setAttribute("user", username);
+          response.sendRedirect("/conversations");
+	}
       } else {
 	setErrorAndRedirect(request, response, "Invalid password.");
       }

--- a/src/main/java/codeu/controller/RootAdminServlet.java
+++ b/src/main/java/codeu/controller/RootAdminServlet.java
@@ -1,0 +1,49 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeu.controller;
+
+import codeu.model.data.Conversation;
+import codeu.model.data.User;
+import codeu.model.store.basic.ConversationStore;
+import codeu.model.store.basic.UserStore;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Servlet class responsible for the Admin page. */
+public class RootAdminServlet extends BaseAdminServlet {
+  private static final String SELF_JSP = "/WEB-INF/view/admin.jsp";
+
+  @Override
+  protected void onValidatedGet(HttpServletRequest request, HttpServletResponse response)
+      throws IOException, ServletException {
+    List<Conversation> conversations = conversationStore.getAllConversations();
+    List<User> users = userStore.getAllUsers();
+    request.setAttribute("conversations", conversations);
+    request.setAttribute("users", users);
+    request.getRequestDispatcher(SELF_JSP).forward(request, response);
+  }
+
+  @Override
+  protected void onValidatedPost(HttpServletRequest request, HttpServletResponse response)
+      throws IOException, ServletException {
+    // Do nothing for now.
+  }
+}

--- a/src/main/java/codeu/controller/UserAdminServlet.java
+++ b/src/main/java/codeu/controller/UserAdminServlet.java
@@ -1,0 +1,50 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeu.controller;
+
+import codeu.model.data.Conversation;
+import codeu.model.data.User;
+import codeu.model.store.basic.ConversationStore;
+import codeu.model.store.basic.UserStore;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Servlet class responsible for the admin actions for a single user. */
+public class UserAdminServlet extends BaseAdminServlet {
+  private static final String SELF_JSP = "/WEB-INF/view/admin-user.jsp";
+
+  @Override
+  protected void onValidatedGet(HttpServletRequest request, HttpServletResponse response)
+      throws IOException, ServletException {
+    // Note that on the login page, the username is a form parameter, but gets turned into
+    // a user object on the *session*.
+    String username = request.getParameter("username"); 
+    User userToBeShown = userStore.getUser(username);
+    request.setAttribute("userToBeShown", userToBeShown);
+    request.getRequestDispatcher(SELF_JSP).forward(request, response);
+  }
+
+  @Override
+  protected void onValidatedPost(HttpServletRequest request, HttpServletResponse response)
+      throws IOException, ServletException {
+    // Do nothing for now.
+  }
+}

--- a/src/main/java/codeu/controller/UserAdminServlet.java
+++ b/src/main/java/codeu/controller/UserAdminServlet.java
@@ -42,9 +42,37 @@ public class UserAdminServlet extends BaseAdminServlet {
     request.getRequestDispatcher(SELF_JSP).forward(request, response);
   }
 
+  /**
+   * Performs editing of a user.
+   */
   @Override
   protected void onValidatedPost(HttpServletRequest request, HttpServletResponse response)
       throws IOException, ServletException {
-    // Do nothing for now.
+    String username = request.getParameter("username"); 
+    User userToBeEdited = userStore.getUser(username);
+    // TODO(ncjones): there should be better error checking here.
+    if (userToBeEdited != null) {
+      String action = request.getParameter("action");
+      User editedUser;
+      if ("Block".equals(action)) {
+        editedUser = User.blockUser(userToBeEdited);
+        userStore.addUser(editedUser);
+      } else if ("Unblock".equals(action)) {
+        editedUser = User.unblockUser(userToBeEdited);
+        userStore.addUser(editedUser);
+      } else if ("Reset".equals(action)) {
+        String newPassword = request.getParameter("new_password");
+	if (newPassword == null) {
+          newPassword = "password";
+	}
+        editedUser = User.resetPassword(userToBeEdited, newPassword);
+        userStore.addUser(editedUser);
+      } else {
+        // Unsupported command; don't edit anything.
+        editedUser = userToBeEdited;
+      }
+      request.setAttribute("userToBeShown", editedUser);
+    }
+    request.getRequestDispatcher(SELF_JSP).forward(request, response);
   }
 }

--- a/src/main/java/codeu/model/data/Conversation.java
+++ b/src/main/java/codeu/model/data/Conversation.java
@@ -26,6 +26,24 @@ public class Conversation {
   public final UUID owner;
   public final Instant creation;
   public final String title;
+  public final boolean muted;
+
+  /**
+   * Constructs a new Conversation.
+   *
+   * @param id the ID of this Conversation
+   * @param owner the ID of the User who created this Conversation
+   * @param title the title of this Conversation
+   * @param creation the creation time of this Conversation
+   * @param muted whether or not the conversation can continue
+   */
+  public Conversation(UUID id, UUID owner, String title, Instant creation, boolean muted) {
+    this.id = id;
+    this.owner = owner;
+    this.creation = creation;
+    this.title = title;
+    this.muted = muted ;
+  }
 
   /**
    * Constructs a new Conversation.
@@ -36,10 +54,17 @@ public class Conversation {
    * @param creation the creation time of this Conversation
    */
   public Conversation(UUID id, UUID owner, String title, Instant creation) {
-    this.id = id;
-    this.owner = owner;
-    this.creation = creation;
-    this.title = title;
+    this(id, owner, title, creation, false);
+  }
+
+  /** Mute the original conversation; this requires an update to datastore. */
+  public static Conversation muteConversation(Conversation original) {
+    return new Conversation(original.id, original.owner, original.title, original.creation, true);
+  }
+
+  /** Unmute the original conversation; this requires an update to datastore. */
+  public static Conversation unmuteConversation(Conversation original) {
+    return new Conversation(original.id, original.owner, original.title, original.creation, false);
   }
 
   /** Returns the ID of this Conversation. */
@@ -60,5 +85,10 @@ public class Conversation {
   /** Returns the creation time of this Conversation. */
   public Instant getCreationTime() {
     return creation;
+  }
+
+  /** Returns whether this Conversation is muted. */
+  public boolean isMuted() {
+    return muted;
   }
 }

--- a/src/main/java/codeu/model/data/User.java
+++ b/src/main/java/codeu/model/data/User.java
@@ -23,6 +23,7 @@ public class User {
   private final String name;
   private final String password;
   private final Instant creation;
+  private final boolean blocked;
 
   /**
    * Constructs a new User.
@@ -33,10 +34,40 @@ public class User {
    * @param creation the creation time of this User
    */
   public User(UUID id, String name, String password, Instant creation) {
+    this(id, name, password, creation, false);
+  }
+
+  /**
+   * Constructs a new User.
+   *
+   * @param id the ID of this User
+   * @param name the username of this User
+   * @param password the password of this User
+   * @param creation the creation time of this User
+   * @param blocked whether or not the user is blocked
+   */
+  public User(UUID id, String name, String password, Instant creation, boolean blocked) {
     this.id = id;
     this.name = name;
     this.password = password;
     this.creation = creation;
+    this.blocked = blocked;
+  }
+
+  /** Returns a new user that is the same as the old user, but is blocked. */
+  public static User blockUser(User original) {
+    return new User(original.id, original.name, original.password, original.creation, true);
+  }
+
+  /** Returns a new user that is the same as the old user, but is not blocked. */
+  public static User unblockUser(User original) {
+    return new User(original.id, original.name, original.password, original.creation, false);
+  }
+
+
+  /** Edits the password for a particular user, returns a new user. */
+  public static User resetPassword(User original, String password) {
+    return new User(original.id, original.name, password, original.creation, original.blocked);
   }
 
   /** Returns the ID of this User. */
@@ -57,5 +88,9 @@ public class User {
   /** Returns the creation time of this User. */
   public Instant getCreationTime() {
     return creation;
+  }
+
+  public boolean isBlocked() {
+    return blocked;
   }
 }

--- a/src/main/java/codeu/model/store/basic/ConversationStore.java
+++ b/src/main/java/codeu/model/store/basic/ConversationStore.java
@@ -88,6 +88,10 @@ public class ConversationStore {
 
   /** Add a new conversation to the current set of conversations known to the application. */
   public void addConversation(Conversation conversation) {
+    Conversation original = getConversationWithTitle(conversation.getTitle());  
+    if (original != null) {
+      conversations.remove(original);
+    }
     conversations.add(conversation);
     persistentStorageAgent.writeThrough(conversation);
   }

--- a/src/main/java/codeu/model/store/basic/UserStore.java
+++ b/src/main/java/codeu/model/store/basic/UserStore.java
@@ -16,6 +16,7 @@ package codeu.model.store.basic;
 
 import codeu.model.data.User;
 import codeu.model.store.persistence.PersistentStorageAgent;
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -120,5 +121,9 @@ public class UserStore {
    */
   public void setUsers(List<User> users) {
     this.users = users;
+  }
+
+  public ImmutableList<User> getAllUsers() {
+    return ImmutableList.<User>copyOf(this.users);
   }
 }

--- a/src/main/java/codeu/model/store/basic/UserStore.java
+++ b/src/main/java/codeu/model/store/basic/UserStore.java
@@ -99,8 +99,12 @@ public class UserStore {
     return null;
   }
 
-  /** Add a new user to the current set of users known to the application. */
+  /** Add/replace a new user to the current set of users known to the application. */
   public void addUser(User user) {
+    User original = getUser(user.getId());
+    if (original != null) {
+      users.remove(original);
+    }
     users.add(user);
     persistentStorageAgent.writeThrough(user);
   }

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -66,8 +66,11 @@ public class PersistentDataStore {
         String userName = (String) entity.getProperty("username");
         String password = (String) entity.getProperty("password");
         Instant creationTime = Instant.parse((String) entity.getProperty("creation_time"));
+	// Note that any users created prior to this point will not be blocked, because
+	// this fails open.
+	boolean blocked = Boolean.parseBoolean((String) entity.getProperty("blocked"));
 
-        User user = new User(uuid, userName, password, creationTime);
+        User user = new User(uuid, userName, password, creationTime, blocked);
         users.add(user);
       } catch (Exception e) {
         // In a production environment, errors should be very rare. Errors which may
@@ -154,6 +157,7 @@ public class PersistentDataStore {
     userEntity.setProperty("username", user.getName());
     userEntity.setProperty("password", user.getPassword());
     userEntity.setProperty("creation_time", user.getCreationTime().toString());
+    userEntity.setProperty("blocked", Boolean.toString(user.isBlocked()));
     datastore.put(userEntity);
   }
 

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -103,7 +103,8 @@ public class PersistentDataStore {
         UUID ownerUuid = UUID.fromString((String) entity.getProperty("owner_uuid"));
         String title = (String) entity.getProperty("title");
         Instant creationTime = Instant.parse((String) entity.getProperty("creation_time"));
-        Conversation conversation = new Conversation(uuid, ownerUuid, title, creationTime);
+	boolean muted = Boolean.parseBoolean((String) entity.getProperty("muted"));
+        Conversation conversation = new Conversation(uuid, ownerUuid, title, creationTime, muted);
         conversations.add(conversation);
       } catch (Exception e) {
         // In a production environment, errors should be very rare. Errors which may
@@ -179,6 +180,7 @@ public class PersistentDataStore {
     conversationEntity.setProperty("owner_uuid", conversation.getOwnerId().toString());
     conversationEntity.setProperty("title", conversation.getTitle());
     conversationEntity.setProperty("creation_time", conversation.getCreationTime().toString());
+    conversationEntity.setProperty("muted", Boolean.toString(conversation.isMuted()));
     datastore.put(conversationEntity);
   }
 }

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -153,7 +153,7 @@ public class PersistentDataStore {
 
   /** Write a User object to the Datastore service. */
   public void writeThrough(User user) {
-    Entity userEntity = new Entity("chat-users");
+    Entity userEntity = new Entity("chat-users", user.getId().toString());
     userEntity.setProperty("uuid", user.getId().toString());
     userEntity.setProperty("username", user.getName());
     userEntity.setProperty("password", user.getPassword());
@@ -164,7 +164,7 @@ public class PersistentDataStore {
 
   /** Write a Message object to the Datastore service. */
   public void writeThrough(Message message) {
-    Entity messageEntity = new Entity("chat-messages");
+    Entity messageEntity = new Entity("chat-messages", message.getId().toString());
     messageEntity.setProperty("uuid", message.getId().toString());
     messageEntity.setProperty("conv_uuid", message.getConversationId().toString());
     messageEntity.setProperty("author_uuid", message.getAuthorId().toString());
@@ -175,7 +175,7 @@ public class PersistentDataStore {
 
   /** Write a Conversation object to the Datastore service. */
   public void writeThrough(Conversation conversation) {
-    Entity conversationEntity = new Entity("chat-conversations");
+    Entity conversationEntity = new Entity("chat-conversations", conversation.getId().toString());
     conversationEntity.setProperty("uuid", conversation.getId().toString());
     conversationEntity.setProperty("owner_uuid", conversation.getOwnerId().toString());
     conversationEntity.setProperty("title", conversation.getTitle());

--- a/src/main/webapp/WEB-INF/view/admin-conversation.jsp
+++ b/src/main/webapp/WEB-INF/view/admin-conversation.jsp
@@ -42,7 +42,18 @@
           <li>Title: <%= conversation.getTitle() %></li>
           <li>ID: <%= conversation.getId() %></li>
 	  <li>Author: <a href="/admin/user?username=<%= author.getName() %>"><%= author.getName() %></a></li>
-	  <li><input type="submit" value="Mute">|<input type="submit" value="Unmute"></li>
+	  <li><%
+                if (conversation.isMuted()) {
+              %>
+	          <input type="submit" name="action" value="Unmute">
+              <%
+	        } else {
+              %>
+                  <input type="submit" name="action" value="Mute">
+             <%
+                }
+             %>
+	  </li>
         </ul>
       </form>
     <%

--- a/src/main/webapp/WEB-INF/view/admin-conversation.jsp
+++ b/src/main/webapp/WEB-INF/view/admin-conversation.jsp
@@ -1,0 +1,53 @@
+<%--
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ page import="codeu.model.data.Conversation" %>
+<%@ page import="codeu.model.data.User" %>
+
+<!DOCTYPE html>
+<html>
+<%@ include file = "../../header.jsp" %>
+<body>
+  <div id="container">
+
+    <% if(request.getAttribute("error") != null){ %>
+        <h2 style="color:red"><%= request.getAttribute("error") %></h2>
+    <% } %>
+
+    <h1>The Scintillating Conversation</h1>
+
+    <%
+      Conversation conversation = (Conversation) request.getAttribute("conversationToBeShown");
+      User author = (User) request.getAttribute("author");
+      if (conversation == null) {
+    %>
+      <p>That's weird. The conversation is goneversation.</p>
+    <%
+      } else {
+    %>
+      <form method="POST">
+        <ul class="mdl-list">
+          <li>Title: <%= conversation.getTitle() %></li>
+          <li>ID: <%= conversation.getId() %></li>
+	  <li>Author: <a href="/admin/user?username=<%= author.getName() %>"><%= author.getName() %></a></li>
+	  <li><input type="submit" value="Mute">|<input type="submit" value="Unmute"></li>
+        </ul>
+      </form>
+    <%
+    }
+    %>
+  </div>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/view/admin-user.jsp
+++ b/src/main/webapp/WEB-INF/view/admin-user.jsp
@@ -37,9 +37,15 @@
     %>
       <form method="POST">
         <ul class="mdl-list">
-          <li>User: <%= user.getName() %> | <input type="submit" value="Block"> | <input type="submit" value="Unblock"></li> 
+          <li>User: <%= user.getName() %> |
+            <% if (user.isBlocked()) { %>
+              <input type="submit" name="action" value="Unblock">
+            <% } else { %>
+              <input type="submit" name="action" value="Block">
+            <% } %>
+          </li> 
           <li>ID: <%= user.getId() %></li>
-          <li>Password: <input type="submit" value="reset"></li>
+	  <li>Reset password: <input type="text" name="new_password"><input type="submit" name="action" value="Reset"></li>
         </ul>
       </form>
     <%

--- a/src/main/webapp/WEB-INF/view/admin-user.jsp
+++ b/src/main/webapp/WEB-INF/view/admin-user.jsp
@@ -1,0 +1,50 @@
+<%--
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ page import="codeu.model.data.User" %>
+
+<!DOCTYPE html>
+<html>
+<%@ include file = "../../header.jsp" %>
+<body>
+  <div id="container">
+
+    <% if(request.getAttribute("error") != null){ %>
+        <h2 style="color:red"><%= request.getAttribute("error") %></h2>
+    <% } %>
+
+    <h1>The Esteemed User</h1>
+
+    <%
+      User user = (User) request.getAttribute("userToBeShown");
+      if (user == null) {
+    %>
+      <p>User?! What user? We don't have no stinkin' user!</p>
+    <%
+      } else {
+    %>
+      <form method="POST">
+        <ul class="mdl-list">
+          <li>User: <%= user.getName() %> | <input type="submit" value="Block"> | <input type="submit" value="Unblock"></li> 
+          <li>ID: <%= user.getId() %></li>
+          <li>Password: <input type="submit" value="reset"></li>
+        </ul>
+      </form>
+    <%
+    }
+    %>
+  </div>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/view/admin.jsp
+++ b/src/main/webapp/WEB-INF/view/admin.jsp
@@ -40,7 +40,7 @@
       for(Conversation conversation : conversations) {
     %>
       <li>
-        <a href="/admin/conversation?conversation_id=<%= conversation.getId() %>">
+        <a href="/admin/conversation?conversation=<%= conversation.getTitle() %>">
           <%= conversation.getTitle() %>
 	</a>
       </li>
@@ -66,7 +66,7 @@
       for (User user : users) {
     %>
       <li>
-        <a href="/admin/user?user_id=<%= user.getId() %>">
+        <a href="/admin/user?username=<%= user.getName() %>">
           <%= user.getName() %>
 	</a>
       </li>

--- a/src/main/webapp/WEB-INF/view/admin.jsp
+++ b/src/main/webapp/WEB-INF/view/admin.jsp
@@ -1,0 +1,83 @@
+<%--
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ page import="java.util.List" %>
+<%@ page import="codeu.model.data.Conversation" %>
+<%@ page import="codeu.model.data.User" %>
+
+<!DOCTYPE html>
+<html>
+<%@ include file = "../../header.jsp" %>
+<body>
+  <div id="container">
+
+    <% if(request.getAttribute("error") != null){ %>
+        <h2 style="color:red"><%= request.getAttribute("error") %></h2>
+    <% } %>
+
+    <h1>Conversations</h1>
+
+    <%
+    List<Conversation> conversations = (List<Conversation>) request.getAttribute("conversations");
+    if (conversations == null || conversations.isEmpty()) {
+    %>
+      <p>There are <i>no</i> conversations!</p>
+    <% } else { %>
+      <ul class="mdl-list">
+    <%
+      for(Conversation conversation : conversations) {
+    %>
+      <li>
+        <a href="/admin/conversation?conversation_id=<%= conversation.getId() %>">
+          <%= conversation.getTitle() %>
+	</a>
+      </li>
+    <%
+      }
+    %>
+      </ul>
+
+    <%
+    }
+    %>
+
+    <h1>Users</h1>
+
+    <%
+    List<User> users = (List<User>) request.getAttribute("users");
+    if (users == null || users.isEmpty()) {
+    %>
+    <p>There are <i>no</i>users, which is weird, because how could you see this page?</p>
+    <% } else { %>
+      <ul class="mdl-list">
+    <%
+      for (User user : users) {
+    %>
+      <li>
+        <a href="/admin/user?user_id=<%= user.getId() %>">
+          <%= user.getName() %>
+	</a>
+      </li>
+    <%
+      }
+    %>
+      </ul>
+    <%
+    }
+    %>
+    
+  </div>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -52,21 +52,27 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
 
     <div id="chat">
       <ul>
-    <%
-      for (Message message : messages) {
-        String author = UserStore.getInstance()
-          .getUser(message.getAuthorId()).getName();
-    %>
-      <li><strong><%= author %>:</strong> <%= message.getContent() %></li>
-    <%
-      }
-    %>
+        <%
+          if (!conversation.isMuted()) {
+            for (Message message : messages) {
+              String author = UserStore.getInstance()
+                .getUser(message.getAuthorId()).getName();
+            %>
+              <li><strong><%= author %>:</strong> <%= message.getContent() %></li>
+            <%
+            }
+          } else {
+            %>
+	      <li>This conversation is muted.</li>
+	    <%
+	  }
+	%>
       </ul>
     </div>
 
     <hr/>
 
-    <% if (request.getSession().getAttribute("user") != null) { %>
+    <% if (request.getSession().getAttribute("user") != null && !conversation.isMuted()) { %>
     <form action="/chat/<%= conversation.getTitle() %>" method="POST">
         <input type="text" name="message">
         <br/>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -87,13 +87,33 @@
   </servlet-mapping>
 
   <servlet>
-    <servlet-name>AdminServlet</servlet-name>
-    <servlet-class>codeu.controller.AdminServlet</servlet-class>
+    <servlet-name>RootAdminServlet</servlet-name>
+    <servlet-class>codeu.controller.RootAdminServlet</servlet-class>
   </servlet>
 
   <servlet-mapping>
-    <servlet-name>AdminServlet</servlet-name>
+    <servlet-name>RootAdminServlet</servlet-name>
     <url-pattern>/admin</url-pattern>
+  </servlet-mapping>
+
+  <servlet>
+    <servlet-name>UserAdminServlet</servlet-name>
+    <servlet-class>codeu.controller.UserAdminServlet</servlet-class>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>UserAdminServlet</servlet-name>
+    <url-pattern>/admin/user</url-pattern>
+  </servlet-mapping>
+
+  <servlet>
+    <servlet-name>ConversationAdminServlet</servlet-name>
+    <servlet-class>codeu.controller.ConversationAdminServlet</servlet-class>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>ConversationAdminServlet</servlet-name>
+    <url-pattern>/admin/conversation</url-pattern>
   </servlet-mapping>
 
 </web-app>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -86,4 +86,14 @@
     <url-pattern>/register</url-pattern>
   </servlet-mapping>
 
+  <servlet>
+    <servlet-name>AdminServlet</servlet-name>
+    <servlet-class>codeu.controller.AdminServlet</servlet-class>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>AdminServlet</servlet-name>
+    <url-pattern>/admin</url-pattern>
+  </servlet-mapping>
+
 </web-app>

--- a/src/test/java/codeu/controller/AdminServletTest.java
+++ b/src/test/java/codeu/controller/AdminServletTest.java
@@ -1,0 +1,100 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeu.controller;
+
+import static org.mockito.Mockito.*;
+
+import codeu.model.data.Conversation;
+import codeu.model.data.User;
+import codeu.model.store.basic.ConversationStore;
+import codeu.model.store.basic.UserStore;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Mock;
+
+public class AdminServletTest {
+
+  private AdminServlet adminServlet;
+
+  @Mock private HttpServletRequest mockRequest;
+  @Mock private HttpSession mockSession;
+  @Mock private HttpServletResponse mockResponse;
+  @Mock private RequestDispatcher mockRequestDispatcher;
+  @Mock private ConversationStore mockConversationStore;
+  @Mock private UserStore mockUserStore;
+
+  @Before
+  public void setup() {
+    adminServlet = new AdminServlet();
+
+    MockitoAnnotations.initMocks(this);
+    when(mockRequest.getSession()).thenReturn(mockSession);
+
+    when(mockRequest.getRequestDispatcher("/WEB-INF/view/admin.jsp"))
+        .thenReturn(mockRequestDispatcher);
+    adminServlet.setConversationStore(mockConversationStore);
+    adminServlet.setUserStore(mockUserStore);
+  }
+
+  @Test
+  public void testDoGet() throws IOException, ServletException {
+    List<Conversation> fakeConversationList = new ArrayList<>();
+    fakeConversationList.add(
+        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now()));
+    when(mockConversationStore.getAllConversations()).thenReturn(fakeConversationList);
+    when(mockSession.getAttribute("user")).thenReturn("admin");
+
+    adminServlet.doGet(mockRequest, mockResponse);
+
+    verify(mockRequest).setAttribute("conversations", fakeConversationList);
+    verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+  }
+
+  @Test
+  public void testDoGet_UserNotLoggedIn() throws IOException, ServletException {
+    when(mockSession.getAttribute("user")).thenReturn(null);
+
+    adminServlet.doGet(mockRequest, mockResponse);
+
+    verify(mockConversationStore, never())
+        .addConversation(any(Conversation.class));
+    verify(mockResponse).sendRedirect("/login");
+  }
+
+  @Test
+  public void testDoGet_UserNotAdmin() throws IOException, ServletException {
+    when(mockSession.getAttribute("user")).thenReturn("howdy");
+
+    adminServlet.doGet(mockRequest, mockResponse);
+
+    verify(mockConversationStore, never())
+        .addConversation(any(Conversation.class));
+    verify(mockResponse).sendRedirect("/conversations");
+  }
+}

--- a/src/test/java/codeu/controller/BaseAdminServletTest.java
+++ b/src/test/java/codeu/controller/BaseAdminServletTest.java
@@ -1,0 +1,118 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeu.controller;
+
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+import codeu.model.data.Conversation;
+import codeu.model.data.User;
+import codeu.model.store.basic.ConversationStore;
+import codeu.model.store.basic.UserStore;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Mock;
+
+public class BaseAdminServletTest {
+
+  /**
+   * A stubbed (not mocked) subclass of a base admin servlet. Testing subclasses
+   * in mockito is a bit harder, since you actually have to provide an implementation
+   * of pure abstract methods, and this is a quick and dirty way to do it.
+   */
+  private static final class StubbedAdminServlet extends BaseAdminServlet {
+    int numValidatedGetCalls;
+    int numValidatedPostCalls;
+
+    @Override protected void onValidatedGet(
+        HttpServletRequest request, HttpServletResponse response) {
+      ++numValidatedGetCalls;
+    }
+
+    @Override protected void onValidatedPost(
+        HttpServletRequest request, HttpServletResponse response) {
+      ++numValidatedPostCalls;
+    }
+  }
+
+  private StubbedAdminServlet adminServlet;
+
+  @Mock private HttpServletRequest mockRequest;
+  @Mock private HttpSession mockSession;
+  @Mock private HttpServletResponse mockResponse;
+  @Mock private RequestDispatcher mockRequestDispatcher;
+  @Mock private ConversationStore mockConversationStore;
+  @Mock private UserStore mockUserStore;
+
+  @Before
+  public void setup() {
+    adminServlet = new StubbedAdminServlet();
+
+    MockitoAnnotations.initMocks(this);
+    when(mockRequest.getSession()).thenReturn(mockSession);
+
+    when(mockRequest.getRequestDispatcher("/WEB-INF/view/admin.jsp"))
+        .thenReturn(mockRequestDispatcher);
+    adminServlet.setConversationStore(mockConversationStore);
+    adminServlet.setUserStore(mockUserStore);
+  }
+
+  @Test
+  public void testDoGet() throws IOException, ServletException {
+    when(mockSession.getAttribute("user")).thenReturn("admin");
+    adminServlet.doGet(mockRequest, mockResponse);
+    assertEquals(1, adminServlet.numValidatedGetCalls);
+    assertEquals(0, adminServlet.numValidatedPostCalls);
+  }
+
+  @Test
+  public void testDoGet_UserNotLoggedIn() throws IOException, ServletException {
+    when(mockSession.getAttribute("user")).thenReturn(null);
+
+    adminServlet.doGet(mockRequest, mockResponse);
+
+    verify(mockConversationStore, never())
+        .addConversation(any(Conversation.class));
+    verify(mockResponse).sendRedirect("/login");
+    assertEquals(0, adminServlet.numValidatedGetCalls);
+    assertEquals(0, adminServlet.numValidatedPostCalls);
+  }
+
+  @Test
+  public void testDoGet_UserNotAdmin() throws IOException, ServletException {
+    when(mockSession.getAttribute("user")).thenReturn("howdy");
+
+    adminServlet.doGet(mockRequest, mockResponse);
+
+    verify(mockConversationStore, never())
+        .addConversation(any(Conversation.class));
+    verify(mockResponse).sendRedirect("/conversations");
+    assertEquals(0, adminServlet.numValidatedGetCalls);
+    assertEquals(0, adminServlet.numValidatedPostCalls);
+  }
+}

--- a/src/test/java/codeu/controller/ConversationAdminServletTest.java
+++ b/src/test/java/codeu/controller/ConversationAdminServletTest.java
@@ -1,0 +1,83 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeu.controller;
+
+import static org.mockito.Mockito.*;
+
+import codeu.model.data.Conversation;
+import codeu.model.data.User;
+import codeu.model.store.basic.ConversationStore;
+import codeu.model.store.basic.UserStore;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Mock;
+
+public class ConversationAdminServletTest {
+
+  private ConversationAdminServlet adminServlet;
+
+  @Mock private HttpServletRequest mockRequest;
+  @Mock private HttpSession mockSession;
+  @Mock private HttpServletResponse mockResponse;
+  @Mock private RequestDispatcher mockRequestDispatcher;
+  @Mock private ConversationStore mockConversationStore;
+  @Mock private Conversation mockConversation;
+  @Mock private User mockUser;
+  @Mock private UserStore mockUserStore;
+  private UUID authorUUID;
+
+  @Before
+  public void setup() {
+    adminServlet = new ConversationAdminServlet();
+
+    MockitoAnnotations.initMocks(this);
+    when(mockRequest.getSession()).thenReturn(mockSession);
+
+    when(mockRequest.getRequestDispatcher("/WEB-INF/view/admin-conversation.jsp"))
+        .thenReturn(mockRequestDispatcher);
+    adminServlet.setConversationStore(mockConversationStore);
+    adminServlet.setUserStore(mockUserStore);
+    authorUUID = UUID.randomUUID();
+  }
+
+  @Test
+  public void testDoGet() throws IOException, ServletException {
+    when(mockRequest.getParameter("conversation")).thenReturn("foo");
+    when(mockConversationStore.getConversationWithTitle("foo")).thenReturn(mockConversation);
+    when(mockConversation.getOwnerId()).thenReturn(authorUUID);
+    when(mockUserStore.getUser(authorUUID)).thenReturn(mockUser);
+    when(mockSession.getAttribute("user")).thenReturn("admin");
+
+    adminServlet.doGet(mockRequest, mockResponse);
+
+    verify(mockRequest).setAttribute("conversationToBeShown", mockConversation);
+    verify(mockRequest).setAttribute("author", mockUser);
+    verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+  }
+}

--- a/src/test/java/codeu/controller/LoginServletTest.java
+++ b/src/test/java/codeu/controller/LoginServletTest.java
@@ -104,4 +104,20 @@ public class LoginServletTest {
     verify(mockSession).setAttribute("user", "test username");
     verify(mockResponse).sendRedirect("/conversations");
   }
+
+  @Test
+  public void testDoPost_blockedUser() throws IOException, ServletException {
+    when(mockRequest.getParameter("username")).thenReturn("test username");
+    when(mockRequest.getParameter("password")).thenReturn("some password");
+    when(mockUser.getPassword()).thenReturn("some password");
+    when(mockUser.isBlocked()).thenReturn(true);
+    when(mockUserStore.isUserRegistered("test username")).thenReturn(true);
+    when(mockUserStore.getUser("test username")).thenReturn(mockUser);
+    
+    loginServlet.doPost(mockRequest, mockResponse);
+
+    verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+    verify(mockRequest).setAttribute("error", "You have been blocked. Bummer.");
+    verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+  }
 }

--- a/src/test/java/codeu/controller/RootAdminServletTest.java
+++ b/src/test/java/codeu/controller/RootAdminServletTest.java
@@ -38,9 +38,9 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Mock;
 
-public class AdminServletTest {
+public class RootAdminServletTest {
 
-  private AdminServlet adminServlet;
+  private RootAdminServlet adminServlet;
 
   @Mock private HttpServletRequest mockRequest;
   @Mock private HttpSession mockSession;
@@ -51,7 +51,7 @@ public class AdminServletTest {
 
   @Before
   public void setup() {
-    adminServlet = new AdminServlet();
+    adminServlet = new RootAdminServlet();
 
     MockitoAnnotations.initMocks(this);
     when(mockRequest.getSession()).thenReturn(mockSession);

--- a/src/test/java/codeu/controller/UserAdminServletTest.java
+++ b/src/test/java/codeu/controller/UserAdminServletTest.java
@@ -1,0 +1,77 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeu.controller;
+
+import static org.mockito.Mockito.*;
+
+import codeu.model.data.Conversation;
+import codeu.model.data.User;
+import codeu.model.store.basic.ConversationStore;
+import codeu.model.store.basic.UserStore;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Mock;
+
+public class UserAdminServletTest {
+
+  private UserAdminServlet adminServlet;
+
+  @Mock private HttpServletRequest mockRequest;
+  @Mock private HttpSession mockSession;
+  @Mock private HttpServletResponse mockResponse;
+  @Mock private RequestDispatcher mockRequestDispatcher;
+  @Mock private ConversationStore mockConversationStore;
+  @Mock private User mockUser;
+  @Mock private UserStore mockUserStore;
+
+  @Before
+  public void setup() {
+    adminServlet = new UserAdminServlet();
+
+    MockitoAnnotations.initMocks(this);
+    when(mockRequest.getSession()).thenReturn(mockSession);
+
+    when(mockRequest.getRequestDispatcher("/WEB-INF/view/admin-user.jsp"))
+        .thenReturn(mockRequestDispatcher);
+    adminServlet.setConversationStore(mockConversationStore);
+    adminServlet.setUserStore(mockUserStore);
+  }
+
+  @Test
+  public void testDoGet() throws IOException, ServletException {
+    when(mockRequest.getParameter("username")).thenReturn("foo");
+    when(mockUserStore.getUser("foo")).thenReturn(mockUser);
+    when(mockSession.getAttribute("user")).thenReturn("admin");
+
+    adminServlet.doGet(mockRequest, mockResponse);
+
+    verify(mockRequest).setAttribute("userToBeShown", mockUser);
+    verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+  }
+}

--- a/src/test/java/codeu/controller/UserAdminServletTest.java
+++ b/src/test/java/codeu/controller/UserAdminServletTest.java
@@ -74,4 +74,56 @@ public class UserAdminServletTest {
     verify(mockRequest).setAttribute("userToBeShown", mockUser);
     verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
   }
+
+  @Test
+  public void testDoPost_block() throws IOException, ServletException {
+    when(mockRequest.getParameter("username")).thenReturn("foo");
+    when(mockRequest.getParameter("action")).thenReturn("Block");
+    when(mockUserStore.getUser("foo")).thenReturn(mockUser);
+    when(mockSession.getAttribute("user")).thenReturn("admin");
+
+    adminServlet.doPost(mockRequest, mockResponse);
+
+    verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+    verify(mockUserStore).addUser(any());
+  }
+
+  @Test
+  public void testDoPost_unblock() throws IOException, ServletException {
+    when(mockRequest.getParameter("username")).thenReturn("foo");
+    when(mockRequest.getParameter("action")).thenReturn("Unblock");
+    when(mockUserStore.getUser("foo")).thenReturn(mockUser);
+    when(mockSession.getAttribute("user")).thenReturn("admin");
+
+    adminServlet.doPost(mockRequest, mockResponse);
+
+    verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+    verify(mockUserStore).addUser(any());
+  }
+
+  @Test
+  public void testDoPost_reset() throws IOException, ServletException {
+    when(mockRequest.getParameter("username")).thenReturn("foo");
+    when(mockRequest.getParameter("action")).thenReturn("Reset");
+    when(mockUserStore.getUser("foo")).thenReturn(mockUser);
+    when(mockSession.getAttribute("user")).thenReturn("admin");
+
+    adminServlet.doPost(mockRequest, mockResponse);
+
+    verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+    verify(mockUserStore).addUser(any());
+  }
+
+  @Test
+  public void testDoPost_notACommand() throws IOException, ServletException {
+    when(mockRequest.getParameter("username")).thenReturn("foo");
+    when(mockRequest.getParameter("action")).thenReturn("BLAAAH");
+    when(mockUserStore.getUser("foo")).thenReturn(mockUser);
+    when(mockSession.getAttribute("user")).thenReturn("admin");
+
+    adminServlet.doPost(mockRequest, mockResponse);
+
+    verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+    verify(mockUserStore, never()).addUser(any());
+  }
 }

--- a/src/test/java/codeu/model/data/UserTest.java
+++ b/src/test/java/codeu/model/data/UserTest.java
@@ -34,5 +34,14 @@ public class UserTest {
     Assert.assertEquals(name, user.getName());
     Assert.assertEquals(password, user.getPassword());
     Assert.assertEquals(creation, user.getCreationTime());
+    Assert.assertFalse(user.isBlocked());
+
+    user = new User(id, name, password, creation, true);
+
+    Assert.assertEquals(id, user.getId());
+    Assert.assertEquals(name, user.getName());
+    Assert.assertEquals(password, user.getPassword());
+    Assert.assertEquals(creation, user.getCreationTime());
+    Assert.assertTrue(user.isBlocked());
   }
 }

--- a/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
@@ -20,6 +20,8 @@ public class ConversationStoreTest {
       new Conversation(
           UUID.randomUUID(), UUID.randomUUID(), "conversation_one", Instant.ofEpochMilli(1000));
 
+  private final Conversation MUTED_CONVERSATION_ONE = Conversation.muteConversation(CONVERSATION_ONE);
+
   @Before
   public void setup() {
     mockPersistentStorageAgent = Mockito.mock(PersistentStorageAgent.class);
@@ -28,6 +30,16 @@ public class ConversationStoreTest {
     final List<Conversation> conversationList = new ArrayList<>();
     conversationList.add(CONVERSATION_ONE);
     conversationStore.setConversations(conversationList);
+  }
+
+  @Test
+  public void testAddConversation_editExistingConversation() {
+    Assert.assertEquals(1, conversationStore.getAllConversations().size());
+    conversationStore.addConversation(MUTED_CONVERSATION_ONE);
+    Assert.assertEquals(1, conversationStore.getAllConversations().size());
+    Mockito.verify(mockPersistentStorageAgent).writeThrough(MUTED_CONVERSATION_ONE);
+    Conversation storedConversation = conversationStore.getConversationWithTitle(CONVERSATION_ONE.getTitle());
+    assertEquals(MUTED_CONVERSATION_ONE, storedConversation);
   }
 
   @Test
@@ -78,5 +90,7 @@ public class ConversationStoreTest {
     Assert.assertEquals(expectedConversation.getTitle(), actualConversation.getTitle());
     Assert.assertEquals(
         expectedConversation.getCreationTime(), actualConversation.getCreationTime());
+    Assert.assertEquals(
+        expectedConversation.isMuted(), actualConversation.isMuted());
   }
 }

--- a/src/test/java/codeu/model/store/basic/UserStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/UserStoreTest.java
@@ -22,6 +22,7 @@ public class UserStoreTest {
       new User(UUID.randomUUID(), "test_username_two", "password two", Instant.ofEpochMilli(2000));
   private final User USER_THREE =
       new User(UUID.randomUUID(), "test_username_three", "password three", Instant.ofEpochMilli(3000));
+  private final User BLOCKED_USER_ONE = User.blockUser(USER_ONE);
 
   @Before
   public void setup() {
@@ -33,6 +34,18 @@ public class UserStoreTest {
     userList.add(USER_TWO);
     userList.add(USER_THREE);
     userStore.setUsers(userList);
+  }
+
+  @Test
+  public void testAddUser_editExistingUser() {
+    Assert.assertEquals(3, userStore.getAllUsers().size());
+    userStore.addUser(BLOCKED_USER_ONE);
+    // Very important this doesn't go up by one, because that would leave the old
+    // user still in place
+    Assert.assertEquals(3, userStore.getAllUsers().size());
+    Mockito.verify(mockPersistentStorageAgent).writeThrough(BLOCKED_USER_ONE);
+    User storedUser = userStore.getUser(BLOCKED_USER_ONE.getId());
+    assertEquals(BLOCKED_USER_ONE, storedUser);
   }
 
   @Test
@@ -89,5 +102,6 @@ public class UserStoreTest {
     Assert.assertEquals(expectedUser.getName(), actualUser.getName());
     Assert.assertEquals(expectedUser.getPassword(), actualUser.getPassword());
     Assert.assertEquals(expectedUser.getCreationTime(), actualUser.getCreationTime());
+    Assert.assertEquals(expectedUser.isBlocked(), actualUser.isBlocked());
   }
 }

--- a/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
@@ -39,12 +39,18 @@ public class PersistentDataStoreTest {
   @Test
   public void testSaveAndLoadUsers() throws PersistentDataStoreException {
     UUID idOne = UUID.randomUUID();
+    UUID idTwo = UUID.randomUUID();
+    if (idTwo.toString().compareTo(idOne.toString()) < 0) {
+      UUID temp = idTwo;
+      idTwo = idOne;
+      idOne = temp;
+    }
+
     String nameOne = "test_username_one";
     String passwordOne = "password_one";
     Instant creationOne = Instant.ofEpochMilli(1000);
     User inputUserOne = new User(idOne, nameOne, passwordOne, creationOne);
 
-    UUID idTwo = UUID.randomUUID();
     String nameTwo = "test_username_two";
     String passwordTwo = "password_two";
     Instant creationTwo = Instant.ofEpochMilli(2000);
@@ -74,12 +80,17 @@ public class PersistentDataStoreTest {
   @Test
   public void testSaveAndLoadConversations() throws PersistentDataStoreException {
     UUID idOne = UUID.randomUUID();
+    UUID idTwo = UUID.randomUUID();
+    if (idTwo.toString().compareTo(idOne.toString()) < 0) {
+      UUID temp = idTwo;
+      idTwo = idOne;
+      idOne = temp;
+    }
     UUID ownerOne = UUID.randomUUID();
     String titleOne = "Test_Title";
     Instant creationOne = Instant.ofEpochMilli(1000);
     Conversation inputConversationOne = new Conversation(idOne, ownerOne, titleOne, creationOne);
 
-    UUID idTwo = UUID.randomUUID();
     UUID ownerTwo = UUID.randomUUID();
     String titleTwo = "Test_Title_Two";
     Instant creationTwo = Instant.ofEpochMilli(2000);
@@ -109,6 +120,12 @@ public class PersistentDataStoreTest {
   @Test
   public void testSaveAndLoadMessages() throws PersistentDataStoreException {
     UUID idOne = UUID.randomUUID();
+    UUID idTwo = UUID.randomUUID();
+    if (idTwo.toString().compareTo(idOne.toString()) < 0) {
+      UUID temp = idTwo;
+      idTwo = idOne;
+      idOne = temp;
+    }
     UUID conversationOne = UUID.randomUUID();
     UUID authorOne = UUID.randomUUID();
     String contentOne = "test content one";
@@ -116,7 +133,6 @@ public class PersistentDataStoreTest {
     Message inputMessageOne =
         new Message(idOne, conversationOne, authorOne, contentOne, creationOne);
 
-    UUID idTwo = UUID.randomUUID();
     UUID conversationTwo = UUID.randomUUID();
     UUID authorTwo = UUID.randomUUID();
     String contentTwo = "test content one";


### PR DESCRIPTION
Overall design is here:
https://docs.google.com/document/d/18RtLGeJRiEH6duUrtUnUq-eiE4vq-xoUX6zoXcXOqu8/edit#

This is the first step in adding some admin pages that could be used for a number of things. The basic design is described in the above document, specifically you should know we're kind of being hacky and just using a sentinel user named "admin" to grant admin permissions.  This is also a fairly bare-bones idea behind admin, and there are lots of ancillary tasks.

This PR specifically:
  - adds guava (https://github.com/google/guava) into pom.xml, because guava is helpful
  - adds AdminServlet and test, and a jsp
  - adds a method to UserStore to get all users. This is problematic, but we have deliberately chosen not to worry about scaling to hundreds or thousands of users.